### PR TITLE
修复past_controllers代码错误

### DIFF
--- a/app/controllers/past_projects_controller.rb
+++ b/app/controllers/past_projects_controller.rb
@@ -7,6 +7,8 @@ class PastProjectsController < ApplicationController
     if !@project.expired?
       redirect_to project_path(@project)
     end
+    @projects = Project.find_all_ongoing.reverse
+    @projects.delete(@project)
   end
 
   def project_layout


### PR DESCRIPTION
```
原因：past_project_controllers里之前没有定义@projects变量却在Views里调用了
modified:   app/controllers/past_projects_controller.rb
```
