### PR TITLE
Card 108  修复chrome题集页滑动时会跳回顶部的错误

### DIFF
--- a/app/assets/stylesheets/mobile/home.css.scss.erb
+++ b/app/assets/stylesheets/mobile/home.css.scss.erb
@@ -286,3 +286,10 @@
     }
   }
 }
+
+.ui-panel .ui-panel-inner {
+    overflow: auto;
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    -webkit-overflow-scrolling: touch;
+}


### PR DESCRIPTION
原因可能为panel中计算高度出错导至跳回顶部，但没有找到直接解决方法
这次修改将panel与中间的内容滑动分离，不会再出现跳回顶部的问题
