### PR TITLE
Faster answering

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -86,6 +86,12 @@ class Question < ActiveRecord::Base
   end
 
   def correct_rate
+
+    if question_trace.nil?
+      question_trace = QuestionTrace.find_or_initialize_by_question_id id
+      question_trace.save
+    end
+    
     if question_trace.total_num != 0
       "%.2f" % (question_trace.corrent_num * 100.0 / question_trace.total_num)
     else 


### PR DESCRIPTION
修复新上线题集无法答题问题，原因是新上线的题目之前没有自动创建question_trace
