### PR TITLE
Card 136 调整答题事件触发的顺序

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     jquery-rails (2.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery_mobile_rails (1.4.4)
+      railties (>= 3.1.0)
     json (1.8.1)
     jwt (0.1.6)
       multi_json (>= 1.0)
@@ -320,6 +322,7 @@ DEPENDENCIES
   haml (~> 3.1.3)
   haml_coffee_assets
   jquery-rails
+  jquery_mobile_rails (~> 1.4.2)
   kaminari
   less-rails
   mysql2

--- a/app/views/mobile/questions/next.js.erb
+++ b/app/views/mobile/questions/next.js.erb
@@ -1,8 +1,5 @@
 <%if params["project_id"].to_i==12%>
 $(".content").html('<%= escape_javascript(render :partial => 'question', :locals => {:question => @question, :choices => @choices, :answered => false}) %>');
-<%elsif params["project_id"].to_i!=12 and session[:show_share] and session[:show_share][current_project.id] %>
-  <%- session[:show_share].delete current_project.id %>
-  $(".content").html('<%= escape_javascript(render :partial => 'share') %>');
 <% else %>
   $(".content").html('<%= escape_javascript(render :partial => 'question', :locals => {:question => @question, :choices => @choices, :answered => false}) %>');
 <% end %>

--- a/app/views/mobile/questions/share.js.erb
+++ b/app/views/mobile/questions/share.js.erb
@@ -1,0 +1,1 @@
+$(".content").html('<%= escape_javascript(render :partial => 'share') %>');


### PR DESCRIPTION
现在如果题集答空和显示分享的事件同时出现，会先触发题集答空
从代码逻辑角度需要显示分享时可以不用random新题目，所以把这一部分以及判断需要登录的部分提到前面
